### PR TITLE
Updated the class_id2esci_label variable

### DIFF
--- a/classification_identification/inference.py
+++ b/classification_identification/inference.py
@@ -38,10 +38,10 @@ def main():
 
     """ 0. Init variables """
     class_id2esci_label = {
-        0 : 'irrelevant',
-        1 : 'substitute',
-        2 : 'exact',
-        3 : 'complement',
+        0 : 'E',
+        1 : 'S',
+        2 : 'C',
+        3 : 'I',
     }
     class_id2substitute_identification = {
         0 : 'no_substitute',


### PR DESCRIPTION
The class_id2esci_label was not the same mapping as Line 45 of build_input_data_model.py
This was causing an error which returned a 0 macro-f1 and 0 micro-f1.
I have changed the class_id2esci_label to make the mapping same.
I tested the code locally and the performance was;
Task 2: Macro, micro = (0.228, 0.621)
Task 3: Macro, micro = ( 0.439, 0.760)
Please add the changes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
